### PR TITLE
Fix date format for garminconnect lib

### DIFF
--- a/garmin_to_fittrackee/main.py
+++ b/garmin_to_fittrackee/main.py
@@ -147,7 +147,7 @@ def sync(
             f"to {end_datetime.to_formatted_date_string()}"
         )
         activities = garmin.get_activities_by_date(
-            start_datetime.isoformat(), end_datetime.isoformat()
+            start_datetime.to_date_string(), end_datetime.to_date_string()
         )
         if activities:
             for activity in activities:


### PR DESCRIPTION
Fix date format for garminconnect lib. Required a date instead an ISO date ( #11 )